### PR TITLE
Fix issue #26

### DIFF
--- a/lib/haste/uploader.rb
+++ b/lib/haste/uploader.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'faraday'
+require 'uri'
 
 module Haste
 
@@ -41,7 +42,9 @@ module Haste
     private
 
     def do_post(data)
-      connection.post('/documents', data)
+      posturi= URI.parse(server_url)
+      posturi.path += '/documents'
+      connection.post(posturi.path, data)
     end
 
     def connection


### PR DESCRIPTION
This small patch fixes the issue when the hastebin application is deployed to the non default path on the web-server.

_Test with non default server_

> [me@localhost ]$ echo "hello" | HASTE_SERVER='http://my.webserver.com/paste' haste 
> _http://me.mywebserver.com/paste/ohezuqeray_

_Test with default server_

> [me@localhost ]$ unset HASTE_SERVER
> [me@localhost ]$ echo "hello" | haste 
> http://hastebin.com/esacamudap
